### PR TITLE
Add website black-listing

### DIFF
--- a/banned_message.txt
+++ b/banned_message.txt
@@ -1,1 +1,1 @@
-Your recent message was removed due to containing a blacklisted website. If you belive this was in error please contact a mod.
+Your recent message was removed because it contained a blacklisted website / term. If you believe this was in error please contact a mod.

--- a/banned_message.txt
+++ b/banned_message.txt
@@ -1,0 +1,1 @@
+Your recent message was removed due to containing a blacklisted website. If you belive this was in error please contact a mod.

--- a/banned_sites.txt
+++ b/banned_sites.txt
@@ -1,0 +1,8 @@
+copper3d.com
+linkedin.com/company/copper3d
+linkedin.com/feed/hashtag/?keywords=nanohack&highlightedUpdateUrns=urn%3Ali%3Aactivity%3A6646358717241663488
+linkedin.com/company/copper3d/
+3dgbire.com/collections/filaments/copper3d
+linkedin.com/in/paul-croft-b6b94b1b
+thingiverse.com/thing:4225667
+imgur.com/gallery/Mkem2VK

--- a/main.py
+++ b/main.py
@@ -600,7 +600,7 @@ async def on_ready():
         await benchybot.change_presence(activity=discord.Game(CONFIG['name']))
 
 # on_message event - Called whenever a message is sent on the server - this overwrites default behaviour.
-@bot.event
+@benchybot.event
 async def on_message(message):
     # Un-comment to enable full output:
     #print(f"{message.channel}: {message.author}: {message.content}")
@@ -611,7 +611,7 @@ async def on_message(message):
         await message.author.send(banned_message_string)
 
     # Process commands
-    await bot.process_commands(message)
+    await benchybot.process_commands(message)
 
 ##############
 ###Commands###
@@ -677,8 +677,8 @@ async def checkemails(ctx, last_uid):
     else:
         await ctx.send("No new emails")
 
-@bot.command()
-@commands.has_any_role(690993018357940244, 167872530860867586, 167872106644635648)
+@benchybot.command()
+@commands.check(is_staff)
 async def reload_banned_sites(ctx):
     try:
         banned_sites = open("banned_sites.txt", "r").readlines()
@@ -689,8 +689,8 @@ async def reload_banned_sites(ctx):
         print("[✘] Banned sites list could not be updated.")
         await ctx.send("Oops! Somethign went wrong!")
 
-@bot.command()
-@commands.has_any_role(690993018357940244, 167872530860867586, 167872106644635648)
+@benchybot.command()
+@commands.check(is_staff)
 async def add_banned_site(ctx, arg):
     try:
         print("appending")
@@ -702,7 +702,7 @@ async def add_banned_site(ctx, arg):
         print("[✘] Could not add banned site")
         await ctx.send("Oops! Somethign went wrong!")
 
-@benchybt.event
+@benchybot.event
 async def on_command_error(ctx, error):
     """
     Parses command database since library sees them as an error

--- a/main.py
+++ b/main.py
@@ -67,6 +67,23 @@ BASE.metadata.create_all(ENGINE)
 SESSION = sessionmaker(bind=ENGINE)
 COMMANDDB = SESSION()
 
+# Load banned sites
+try:
+    banned_sites = open("banned_sites.txt", "r").readlines()
+    banned_sites = [line.rstrip("\n") for line in banned_sites]
+    print(f"[✓] Banned sites loaded: {len(banned_sites)}")
+except:
+    print("[✘] Banned sites list not found. Please create banned_sites.txt with your banned sites.")
+    exit()
+
+# Load banned site Message
+try:
+    banned_message_string = open("banned_message.txt", "r").read()
+    print(f"[✓] Banned sites message loaded: {banned_message_string}")
+except:
+    print("[✘] Banned message list not found. Please create banned_message.txt with your banned message.")
+    exit()
+
 #Discord client
 benchybot = commands.Bot(command_prefix=CONFIG['prefix'])
 
@@ -582,6 +599,19 @@ async def on_ready():
     if CONFIG['show_status'] == True:
         await benchybot.change_presence(activity=discord.Game(CONFIG['name']))
 
+# on_message event - Called whenever a message is sent on the server - this overwrites default behaviour.
+@bot.event
+async def on_message(message):
+    # Un-comment to enable full output:
+    #print(f"{message.channel}: {message.author}: {message.content}")
+
+    # Delete banned websites
+    if (any(s in message.content.lower() for s in banned_sites)):
+        await message.delete()
+        await message.author.send(banned_message_string)
+
+    # Process commands
+    await bot.process_commands(message)
 
 ##############
 ###Commands###
@@ -647,8 +677,36 @@ async def checkemails(ctx, last_uid):
     else:
         await ctx.send("No new emails")
 
+@bot.command()
+async def ping(ctx):
+    await ctx.send("Pong!")
 
-@benchybot.event
+@bot.command()
+@commands.has_any_role(690993018357940244, 167872530860867586, 167872106644635648)
+async def reload_banned_sites(ctx):
+    try:
+        banned_sites = open("banned_sites.txt", "r").readlines()
+        banned_sites = [line.rstrip("\n") for line in banned_sites]
+        await ctx.send(f"Done!")
+        print(f"[✓] Banned sites updated: {len(banned_sites)}")
+    except:
+        print("[✘] Banned sites list could not be updated.")
+        await ctx.send("Oops! Somethign went wrong!")
+
+@bot.command()
+@commands.has_any_role(690993018357940244, 167872530860867586, 167872106644635648)
+async def add_banned_site(ctx, arg):
+    try:
+        print("appending")
+        with open("banned_sites.txt", "a") as working_file:
+            working_file.write(f"\n{arg}")
+        print("done!")
+        await ctx.send(f"Done!")
+    except:
+        print("[✘] Could not add banned site")
+        await ctx.send("Oops! Somethign went wrong!")
+
+@benchybt.event
 async def on_command_error(ctx, error):
     """
     Parses command database since library sees them as an error

--- a/main.py
+++ b/main.py
@@ -678,10 +678,6 @@ async def checkemails(ctx, last_uid):
         await ctx.send("No new emails")
 
 @bot.command()
-async def ping(ctx):
-    await ctx.send("Pong!")
-
-@bot.command()
 @commands.has_any_role(690993018357940244, 167872530860867586, 167872106644635648)
 async def reload_banned_sites(ctx):
     try:


### PR DESCRIPTION
Quick update to add blacklisting of certain websites / phrases. 

Blacklist catching is done in the on_message event. 

add blacklisted terms with !add_banned_site and reload banned sites with !reload_banned_sites

Both commands are set to only run if user is part of Admin, Mod, or Temporary staff roles. 

